### PR TITLE
Handle www subdomain

### DIFF
--- a/blog-copier.php
+++ b/blog-copier.php
@@ -119,6 +119,12 @@ if ( !class_exists('BlogCopier') ) {
 				}
 			} else {
 				$copy_files = true; // set the default for first page load
+				if ( $from_blog_id === -1 ) {
+					$last_copy = get_site_option( 'copy_blog_latest', array() );
+					if ( is_array( $last_copy ) && ! empty( $last_copy[ 'from_id' ] ) ) {
+						$from_blog_id = (int) $last_copy[ 'from_id' ];
+					}
+				}
 			} ?>
 			<div class='wrap'><h2><?php echo $this->_name; ?></h2><?php
 
@@ -249,6 +255,13 @@ if ( !class_exists('BlogCopier') ) {
 						$this->replace_content_urls( $from_blog_id, $to_blog_id );
 
 					}
+
+					update_site_option( 'copy_blog_latest', array(
+						'from_id' => $from_blog_id,
+						'to_id'   => $to_blog_id,
+						'domain'  => $newdomain,
+						'path'    => $path,
+					) );
 					$msg = sprintf(__( 'Copied: %s in %s seconds', $this->_domain ),'<a href="http://'.$newdomain.'" target="_blank">'.$title.'</a>', number_format_i18n(timer_stop()));
 					do_action( 'log', __( 'Copy Complete!', $this->_domain ), $this->_domain, $msg );
 					do_action( 'copy_blog_complete', $from_blog_id, $to_blog_id );

--- a/blog-copier.php
+++ b/blog-copier.php
@@ -168,7 +168,7 @@ if ( !class_exists('BlogCopier') ) {
 								<th scope='row'><?php _e( 'New Blog Address', $this->_domain ); ?></th>
 								<td>
 								<?php if( is_subdomain_install() ) { ?>
-									<input name="blog[domain]" type="text" title="<?php _e( 'Subdomain', $this->_domain ); ?>" class="regular-text"/>.<?php echo $current_site->domain;?>
+									<input name="blog[domain]" type="text" title="<?php _e( 'Subdomain', $this->_domain ); ?>" class="regular-text"/>.<?php echo preg_replace( '|^www\.|', '', $current_site->domain );?>
 								<?php } else {
 									echo $current_site->domain . $current_site->path ?><input name="blog[domain]" type="text" title="<?php _e( 'Domain', $this->_domain ); ?>" class="regular-text"/>
 								<?php } ?>
@@ -221,7 +221,7 @@ if ( !class_exists('BlogCopier') ) {
 			$user_id = apply_filters('copy_blog_user_id', $user_id, $from_blog_id);
 
 			if( is_subdomain_install() ) {
-				$newdomain = $domain.".".$current_site->domain;
+				$newdomain = $domain . "." . preg_replace( '|^www\.|', '', $current_site->domain );
 				$path = $base;
 			} else {
 				$newdomain = $current_site->domain;

--- a/blog-copier.php
+++ b/blog-copier.php
@@ -3,7 +3,7 @@
 Plugin Name: Blog Copier
 Plugin URI: http://wordpress.org/extend/plugins/blog-copier/
 Description: Enables superusers to copy existing sub blogs to new sub blogs.
-Version: 1.0.7
+Version: 1.1
 Author: Modern Tribe, Inc.
 Network: true
 Author URI: http://tri.be

--- a/blog-copier.php
+++ b/blog-copier.php
@@ -91,8 +91,7 @@ if ( !class_exists('BlogCopier') ) {
 
 			$from_blog = false;
 			$copy_id = 0;
-			$nonce_string = sprintf( '%s-%s', $this->_domain, $copy_id );
-			if( isset($_GET['blog']) && wp_verify_nonce( $_GET['_wpnonce'], $nonce_string ) ) {
+			if( isset($_GET['blog']) && wp_verify_nonce( $_GET['_wpnonce'], sprintf( '%s-%s', $this->_domain, $_GET['blog'] ) ) ) {
 				$copy_id = (int)$_GET['blog'];
 				$from_blog = get_blog_details( $copy_id );
 				if( $from_blog->site_id != $current_site->id ) {

--- a/blog-copier.php
+++ b/blog-copier.php
@@ -3,7 +3,7 @@
 Plugin Name: Blog Copier
 Plugin URI: http://wordpress.org/extend/plugins/blog-copier/
 Description: Enables superusers to copy existing sub blogs to new sub blogs.
-Version: 1.1
+Version: 1.2
 Author: Modern Tribe, Inc.
 Network: true
 Author URI: http://tri.be

--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,11 @@ This DOES NOT copy blogs across networks, back up blogs off the network, or copy
 
 == Changelog ==
 
+= 1.1 =
+
+* Remember the last source blog to use as the default for the next copy
+* Fix broken nonce validation from the "Copy" link in the sites lists
+
 = 1.0.7 =
 
 * Add 'copy_blog_complete' action. (thanks @mat-lipe)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate Link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: copy, duplicate, replicate, blog, site, duplicator, replicator, moderntribe, tribe, wpmu, multisite, network, superadmin
 Requires at least: 3.0
 Tested up to: 3.9.2
-Stable tag: 1.0.7
+Stable tag: 1.1
 
 Enables superusers to copy existing sub blogs to new sub blogs.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate Link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: copy, duplicate, replicate, blog, site, duplicator, replicator, moderntribe, tribe, wpmu, multisite, network, superadmin
 Requires at least: 3.0
 Tested up to: 3.9.2
-Stable tag: 1.1
+Stable tag: 1.2
 
 Enables superusers to copy existing sub blogs to new sub blogs.
 
@@ -56,6 +56,10 @@ It's pretty straight forward. Select the blog you want to copy. Set a new domain
 This DOES NOT copy blogs across networks, back up blogs off the network, or copy the master blog. This also does NOT copy users from one blog to another.
 
 == Changelog ==
+
+= 1.2 =
+
+* If the network domain starts with "www.", remove it for new subdomains
 
 = 1.1 =
 


### PR DESCRIPTION
This builds off of the still-pending PR #1 .

If the network URL has a "www." (e.g., "www.example.com"), drop the "www" when copying to new subdomains. This follows the same pattern that WP core uses when creating new blogs.